### PR TITLE
Optimize performance of reading log entries from log files.

### DIFF
--- a/internal/tan/logdb.go
+++ b/internal/tan/logdb.go
@@ -350,7 +350,11 @@ func (l *LogDB) IterateEntries(ents []pb.Entry,
 	if err != nil {
 		return nil, 0, err
 	}
-	return db.getEntries(shardID, replicaID, ents, size, low, high, maxSize)
+	_, ok := l.collection.keeper.(*regularKeeper)
+	if ok {
+		return db.getEntries(shardID, replicaID, ents, size, low, high, maxSize)
+	}
+	return db.getEntriesWithMultiplexed(shardID, replicaID, ents, size, low, high, maxSize)
 }
 
 // ReadRaftState returns the persistented raft state found in Log DB.


### PR DESCRIPTION
Replace db.getEntries() with a higher performance one. The new one does not support multiplexed collection which is not used.

The original version almost open log file for each index entry which cause low performance.

The new version open file and keep reading log entries until we get a unavailble log entry identified by
(ies[passed].pos-offset)%blockSize != 0. And then reopen the log file from the position of latest index entry. The read operation ends until the size exceeds maxSize or index entires completes traversal.