### PR TITLE
tan: fix bug, one write operation causes multiple sync.

### DIFF
--- a/internal/server/environment_test.go
+++ b/internal/server/environment_test.go
@@ -171,6 +171,7 @@ func testNodeHostDirectoryDetectsMismatches(t *testing.T,
 		RaftAddress:         testAddress,
 		AddressByNodeHostID: addressByNodeHostID,
 	}
+	cfg.Expert.VerifyHostnameChanged = true
 
 	status := raftpb.RaftDataStatus{
 		Address: addr,

--- a/internal/tan/db.go
+++ b/internal/tan/db.go
@@ -85,8 +85,9 @@ type db struct {
 	}
 }
 
+// stateSyncChange returns true iif the states are valid and not equal.
 func stateSyncChange(a, b pb.State) bool {
-	return a.Term != b.Term || a.Vote != b.Vote
+	return pb.IsStateValid(a) && pb.IsStateValid(b) && (a.Term != b.Term || a.Vote != b.Vote)
 }
 
 // write writes the update instance to the log and returns a boolean flag

--- a/internal/tan/node_states.go
+++ b/internal/tan/node_states.go
@@ -53,6 +53,9 @@ func (s *nodeStates) getState(shardID uint64, replicaID uint64) pb.State {
 }
 
 func (s *nodeStates) setState(shardID uint64, replicaID uint64, st pb.State) {
+	if !pb.IsStateValid(st) {
+		return
+	}
 	s.checkNodeInfo(shardID, replicaID)
 	ni := raftio.NodeInfo{ShardID: shardID, ReplicaID: replicaID}
 	s.states[ni] = st

--- a/raftpb/raft.go
+++ b/raftpb/raft.go
@@ -51,6 +51,12 @@ func IsEmptySnapshot(s Snapshot) bool {
 	return s.Index == 0
 }
 
+// IsStateValid returns a boolean flag indicating whether the given state
+// is valid.
+func IsStateValid(s State) bool {
+	return s.Term != 0
+}
+
 // IsStateEqual returns whether two input state instances are equal.
 func IsStateEqual(a State, b State) bool {
 	return isStateEqual(a, b)


### PR DESCRIPTION
We should not update node states and sync disk if the incoming state is invalid.

Also, fix a hostname changed test case.