### PR TITLE
Fix snapshot import config change ID

### DIFF
--- a/nodehost.go
+++ b/nodehost.go
@@ -1046,6 +1046,19 @@ func (nh *NodeHost) SyncRequestImportSnapshot(
 	if !ok {
 		return tools.ErrIncompleteSnapshot
 	}
+	n, ok := nh.getShard(shardID)
+	if !ok {
+		return ErrShardNotFound
+	}
+	if n.replicaID != replicaID {
+		return ErrShardNotFound
+	}
+	if !snapshotMembershipCanBeImported(
+		srcSnapshot.Membership, n.sm.GetMembership(), replicaID) {
+		plog.Errorf("imported snapshot membership has invalid role for replica %d",
+			replicaID)
+		return tools.ErrInvalidMembers
+	}
 	// Get the snapshot destination directory for the replica.
 	ssDir := nh.env.GetSnapshotDir(nh.nhConfig.DeploymentID,
 		srcSnapshot.ShardID, replicaID)
@@ -1070,40 +1083,68 @@ func (nh *NodeHost) SyncRequestImportSnapshot(
 	}
 	dstDir := ssEnv.GetTempDir()
 	finalDir := ssEnv.GetFinalDir()
-	members, err := nh.SyncGetShardMembership(ctx, shardID)
-	if err != nil {
-		return err
-	}
-	mergeMap := func(maps ...map[uint64]string) map[uint64]string {
-		ret := make(map[uint64]string)
-		for _, m := range maps {
-			for k, v := range m {
-				ret[k] = v
-			}
-		}
-		return ret
-	}
-	// Get a new snapshot record, mainly the members. Because members may be different
-	// from those in source snapshot. So we need update members according to current
-	// member in system.
-	ss := tools.GetProcessedSnapshotRecord(
+	ss := tools.GetProcessedSnapshotRecordWithOriginalMembership(
 		finalDir,
 		srcSnapshot,
-		mergeMap(members.Nodes, members.NonVotings, members.Witnesses),
-		members.ConfigChangeID,
 		nh.fs,
-		nh.nhConfig.Expert.MembershipImmovable,
 	)
 	// Just copy source snapshot directory to destination directory.
 	if err := tools.CopySnapshot(srcSnapshot, srcDir, dstDir, nh.fs); err != nil {
 		return err
 	}
-	n, ok := nh.getShard(shardID)
-	if !ok {
-		return ErrShardNotFound
-	}
 	defer nh.engine.setStepReady(shardID)
 	return n.requestImportSnapshot(ss)
+}
+
+type membershipReplicaRole uint64
+
+const (
+	membershipReplicaInvalid membershipReplicaRole = iota
+	membershipReplicaVoting
+	membershipReplicaNonVoting
+	membershipReplicaWitness
+)
+
+func snapshotMembershipCanBeImported(
+	m pb.Membership, current pb.Membership, replicaID uint64,
+) bool {
+	importedRole := getMembershipReplicaRole(m, replicaID)
+	currentRole := getMembershipReplicaRole(current, replicaID)
+	switch importedRole {
+	case membershipReplicaVoting:
+		return currentRole == membershipReplicaVoting ||
+			currentRole == membershipReplicaNonVoting
+	case membershipReplicaNonVoting:
+		return currentRole == membershipReplicaNonVoting
+	case membershipReplicaWitness:
+		return currentRole == membershipReplicaWitness
+	default:
+		return false
+	}
+}
+
+func getMembershipReplicaRole(m pb.Membership, replicaID uint64) membershipReplicaRole {
+	if _, ok := m.Removed[replicaID]; ok {
+		return membershipReplicaInvalid
+	}
+	count := 0
+	role := membershipReplicaInvalid
+	if _, ok := m.Addresses[replicaID]; ok {
+		count++
+		role = membershipReplicaVoting
+	}
+	if _, ok := m.NonVotings[replicaID]; ok {
+		count++
+		role = membershipReplicaNonVoting
+	}
+	if _, ok := m.Witnesses[replicaID]; ok {
+		count++
+		role = membershipReplicaWitness
+	}
+	if count != 1 {
+		return membershipReplicaInvalid
+	}
+	return role
 }
 
 // SyncRequestDeleteReplica is the synchronous variant of the RequestDeleteReplica

--- a/nodehost.go
+++ b/nodehost.go
@@ -1090,6 +1090,7 @@ func (nh *NodeHost) SyncRequestImportSnapshot(
 		finalDir,
 		srcSnapshot,
 		mergeMap(members.Nodes, members.NonVotings, members.Witnesses),
+		members.ConfigChangeID,
 		nh.fs,
 		nh.nhConfig.Expert.MembershipImmovable,
 	)

--- a/nodehost_test.go
+++ b/nodehost_test.go
@@ -4381,6 +4381,101 @@ func TestShardWithoutQuorumCanBeRestoreByImportingSnapshot(t *testing.T) {
 	runNodeHostTestDC(t, tf, true, fs)
 }
 
+func TestSnapshotMembershipCanBeImported(t *testing.T) {
+	const target uint64 = 1
+	addr := "localhost:26001"
+	voting := func() pb.Membership {
+		return pb.Membership{Addresses: map[uint64]string{target: addr}}
+	}
+	nonVoting := func() pb.Membership {
+		return pb.Membership{NonVotings: map[uint64]string{target: addr}}
+	}
+	witness := func() pb.Membership {
+		return pb.Membership{Witnesses: map[uint64]string{target: addr}}
+	}
+	removed := func() pb.Membership {
+		return pb.Membership{
+			Addresses: map[uint64]string{target: addr},
+			Removed:   map[uint64]bool{target: false},
+		}
+	}
+	duplicated := func() pb.Membership {
+		return pb.Membership{
+			Addresses:  map[uint64]string{target: addr},
+			NonVotings: map[uint64]string{target: addr},
+		}
+	}
+	tests := []struct {
+		name     string
+		imported pb.Membership
+		current  pb.Membership
+		ok       bool
+	}{
+		{
+			name:     "voting imports voting",
+			imported: voting(),
+			current:  voting(),
+			ok:       true,
+		},
+		{
+			name:     "voting rejects non-voting",
+			imported: nonVoting(),
+			current:  voting(),
+		},
+		{
+			name:     "voting rejects witness",
+			imported: witness(),
+			current:  voting(),
+		},
+		{
+			name:     "non-voting imports non-voting",
+			imported: nonVoting(),
+			current:  nonVoting(),
+			ok:       true,
+		},
+		{
+			name:     "non-voting imports promoted voting",
+			imported: voting(),
+			current:  nonVoting(),
+			ok:       true,
+		},
+		{
+			name:     "witness imports witness",
+			imported: witness(),
+			current:  witness(),
+			ok:       true,
+		},
+		{
+			name:     "witness rejects voting",
+			imported: voting(),
+			current:  witness(),
+		},
+		{
+			name:     "removed target rejected",
+			imported: removed(),
+			current:  voting(),
+		},
+		{
+			name:     "duplicated target role rejected",
+			imported: duplicated(),
+			current:  voting(),
+		},
+		{
+			name:     "missing target rejected",
+			imported: pb.Membership{Addresses: map[uint64]string{2: "localhost:26002"}},
+			current:  voting(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := snapshotMembershipCanBeImported(
+				tt.imported, tt.current, target); got != tt.ok {
+				t.Fatalf("got %t, want %t", got, tt.ok)
+			}
+		})
+	}
+}
+
 func TestRequestImportSnapshotAndQueryLog(t *testing.T) {
 	if vfs.GetTestFS() != vfs.DefaultFS {
 		t.Skip("not using the default fs")
@@ -4474,11 +4569,85 @@ func TestRequestImportSnapshotAndQueryLog(t *testing.T) {
 		}
 		snapshotDir := fmt.Sprintf("snapshot-%016X", index)
 		dir := fs.PathJoin(sspath, snapshotDir)
+		srcSnapshot, err := tools.GetSnapshotRecord(dir, server.MetadataFilename, fs)
+		if err != nil {
+			t.Fatalf("failed to get source snapshot record %v", err)
+		}
+		assertInvalidSnapshot := func(ss pb.Snapshot) {
+			t.Helper()
+			if err := fileutil.CreateFlagFile(dir, server.MetadataFilename,
+				&ss, fs); err != nil {
+				t.Fatalf("failed to update source snapshot record %v", err)
+			}
+			ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+			err = nh.SyncRequestImportSnapshot(ctx, 1, 1, dir)
+			cancel()
+			if !errors.Is(err, tools.ErrInvalidMembers) {
+				t.Fatalf("got %v, want %v", err, tools.ErrInvalidMembers)
+			}
+		}
+		missingReplica := srcSnapshot
+		missingReplica.Membership = pb.Membership{
+			ConfigChangeId: srcSnapshot.Membership.ConfigChangeId,
+			Addresses:      map[uint64]string{2: "noidea:8080"},
+		}
+		assertInvalidSnapshot(missingReplica)
+		targetAddr, ok := srcSnapshot.Membership.Addresses[1]
+		if !ok {
+			t.Fatalf("source snapshot does not contain target replica")
+		}
+		mismatchedReplica := srcSnapshot
+		mismatchedReplica.Membership = pb.Membership{
+			ConfigChangeId: srcSnapshot.Membership.ConfigChangeId,
+			Addresses:      map[uint64]string{2: "noidea:8080"},
+		}
+		if err := fileutil.CreateFlagFile(dir, server.MetadataFilename,
+			&mismatchedReplica, fs); err != nil {
+			t.Fatalf("failed to update source snapshot record %v", err)
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+		err = nh.SyncRequestImportSnapshot(ctx, 1, 2, dir)
+		cancel()
+		if !errors.Is(err, ErrShardNotFound) {
+			t.Fatalf("got %v, want %v", err, ErrShardNotFound)
+		}
+		removedReplica := srcSnapshot
+		removedReplica.Membership = pb.Membership{
+			ConfigChangeId: srcSnapshot.Membership.ConfigChangeId,
+			Addresses:      map[uint64]string{1: targetAddr},
+			Removed:        map[uint64]bool{1: false},
+		}
+		assertInvalidSnapshot(removedReplica)
+		nonVotingReplica := srcSnapshot
+		nonVotingReplica.Membership = pb.Membership{
+			ConfigChangeId: srcSnapshot.Membership.ConfigChangeId,
+			Addresses:      map[uint64]string{2: "noidea:8080"},
+			NonVotings:     map[uint64]string{1: targetAddr},
+		}
+		assertInvalidSnapshot(nonVotingReplica)
+		witnessReplica := srcSnapshot
+		witnessReplica.Membership = pb.Membership{
+			ConfigChangeId: srcSnapshot.Membership.ConfigChangeId,
+			Addresses:      map[uint64]string{2: "noidea:8080"},
+			Witnesses:      map[uint64]string{1: targetAddr},
+		}
+		assertInvalidSnapshot(witnessReplica)
+		if err := fileutil.CreateFlagFile(dir, server.MetadataFilename,
+			&srcSnapshot, fs); err != nil {
+			t.Fatalf("failed to restore source snapshot record %v", err)
+		}
 		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
 		if err := nh.SyncRequestImportSnapshot(ctx, 1, 1, dir); err != nil {
 			t.Fatalf("failed to import snapshot %v", err)
 		}
 		cancel()
+		logReader, err := nh.GetLogReader(1)
+		if err != nil {
+			t.Fatalf("failed to get log reader %v", err)
+		}
+		imported := logReader.Snapshot()
+		assert.Equal(t, srcSnapshot.Membership, imported.Membership)
+		assert.NotEqual(t, index, imported.Membership.ConfigChangeId)
 
 		// SyncRequestImportSnapshot imports the snapshot synchronously, but compact log entries
 		// asynchronously, this is ok for application because we can accept less compaction.

--- a/tools/import.go
+++ b/tools/import.go
@@ -217,7 +217,6 @@ func ImportSnapshot(nhConfig config.NodeHostConfig,
 		finalDir,
 		oldss,
 		memberNodes,
-		oldss.Membership.ConfigChangeId,
 		fs,
 		nhConfig.Expert.MembershipImmovable,
 	)
@@ -372,31 +371,16 @@ func GetProcessedSnapshotRecord(
 	dstDir string,
 	old pb.Snapshot,
 	members map[uint64]string,
-	configChangeID uint64,
 	fs vfs.IFS,
 	membershipImmovable bool,
 ) pb.Snapshot {
-	for _, file := range old.Files {
-		file.Filepath = fs.PathJoin(dstDir, fs.PathBase(file.Filepath))
-	}
-	ss := pb.Snapshot{
-		Filepath: fs.PathJoin(dstDir, fs.PathBase(old.Filepath)),
-		FileSize: old.FileSize,
-		Index:    old.Index,
-		Term:     old.Term,
-		Checksum: old.Checksum,
-		Dummy:    old.Dummy,
-		Membership: pb.Membership{
-			ConfigChangeId: configChangeID,
-			Removed:        make(map[uint64]bool),
-			NonVotings:     make(map[uint64]string),
-			Addresses:      make(map[uint64]string),
-			Witnesses:      make(map[uint64]string),
-		},
-		Files:    old.Files,
-		Type:     old.Type,
-		ShardID:  old.ShardID,
-		Imported: true,
+	ss := getProcessedSnapshotRecord(dstDir, old, fs)
+	ss.Membership = pb.Membership{
+		ConfigChangeId: old.Membership.ConfigChangeId,
+		Removed:        make(map[uint64]bool),
+		NonVotings:     make(map[uint64]string),
+		Addresses:      make(map[uint64]string),
+		Witnesses:      make(map[uint64]string),
 	}
 	for nid := range old.Membership.Addresses {
 		_, ok := members[nid]
@@ -446,6 +430,73 @@ func GetProcessedSnapshotRecord(
 		}
 	}
 	return ss
+}
+
+func GetProcessedSnapshotRecordWithOriginalMembership(
+	dstDir string,
+	old pb.Snapshot,
+	fs vfs.IFS,
+) pb.Snapshot {
+	ss := getProcessedSnapshotRecord(dstDir, old, fs)
+	ss.Membership = cloneMembership(old.Membership)
+	return ss
+}
+
+func getProcessedSnapshotRecord(
+	dstDir string,
+	old pb.Snapshot,
+	fs vfs.IFS,
+) pb.Snapshot {
+	files := make([]*pb.SnapshotFile, 0, len(old.Files))
+	for _, file := range old.Files {
+		copied := *file
+		copied.Filepath = fs.PathJoin(dstDir, fs.PathBase(file.Filepath))
+		files = append(files, &copied)
+	}
+	return pb.Snapshot{
+		Filepath: fs.PathJoin(dstDir, fs.PathBase(old.Filepath)),
+		FileSize: old.FileSize,
+		Index:    old.Index,
+		Term:     old.Term,
+		Checksum: old.Checksum,
+		Dummy:    old.Dummy,
+		Files:    files,
+		Type:     old.Type,
+		ShardID:  old.ShardID,
+		Imported: true,
+	}
+}
+
+func cloneMembership(m pb.Membership) pb.Membership {
+	return pb.Membership{
+		ConfigChangeId: m.ConfigChangeId,
+		Addresses:      cloneStringMap(m.Addresses),
+		Removed:        cloneBoolMap(m.Removed),
+		NonVotings:     cloneStringMap(m.NonVotings),
+		Witnesses:      cloneStringMap(m.Witnesses),
+	}
+}
+
+func cloneStringMap(m map[uint64]string) map[uint64]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[uint64]string, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func cloneBoolMap(m map[uint64]bool) map[uint64]bool {
+	if m == nil {
+		return nil
+	}
+	result := make(map[uint64]bool, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
 }
 
 func CopySnapshot(ss pb.Snapshot,

--- a/tools/import.go
+++ b/tools/import.go
@@ -217,6 +217,7 @@ func ImportSnapshot(nhConfig config.NodeHostConfig,
 		finalDir,
 		oldss,
 		memberNodes,
+		oldss.Membership.ConfigChangeId,
 		fs,
 		nhConfig.Expert.MembershipImmovable,
 	)
@@ -371,6 +372,7 @@ func GetProcessedSnapshotRecord(
 	dstDir string,
 	old pb.Snapshot,
 	members map[uint64]string,
+	configChangeID uint64,
 	fs vfs.IFS,
 	membershipImmovable bool,
 ) pb.Snapshot {
@@ -385,7 +387,7 @@ func GetProcessedSnapshotRecord(
 		Checksum: old.Checksum,
 		Dummy:    old.Dummy,
 		Membership: pb.Membership{
-			ConfigChangeId: old.Index,
+			ConfigChangeId: configChangeID,
 			Removed:        make(map[uint64]bool),
 			NonVotings:     make(map[uint64]string),
 			Addresses:      make(map[uint64]string),

--- a/tools/import_test.go
+++ b/tools/import_test.go
@@ -293,9 +293,10 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 		Checksum: make([]byte, 8),
 		Dummy:    false,
 		Membership: pb.Membership{
-			Removed:    make(map[uint64]bool),
-			NonVotings: make(map[uint64]string),
-			Addresses:  make(map[uint64]string),
+			ConfigChangeId: 101,
+			Removed:        make(map[uint64]bool),
+			NonVotings:     make(map[uint64]string),
+			Addresses:      make(map[uint64]string),
 		},
 		Type:    pb.OnDiskStateMachine,
 		ShardID: 345,
@@ -322,10 +323,15 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 	members := make(map[uint64]string)
 	members[1] = "a1"
 	members[5] = "a5"
+	configChangeID := uint64(202)
 	finalDir := "final_data"
-	newss := GetProcessedSnapshotRecord(finalDir, ss, members, fs, false)
+	newss := GetProcessedSnapshotRecord(finalDir, ss, members, configChangeID, fs, false)
 	if newss.Index != ss.Index || newss.Term != ss.Term {
 		t.Errorf("index/term not copied")
+	}
+	if newss.Membership.ConfigChangeId != configChangeID {
+		t.Errorf("config change id not copied, %d, want %d",
+			newss.Membership.ConfigChangeId, configChangeID)
 	}
 	if newss.Dummy != ss.Dummy || newss.ShardID != ss.ShardID || newss.Type != ss.Type {
 		t.Errorf("dummy/ShardId/Type fields not copied")

--- a/tools/import_test.go
+++ b/tools/import_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/lni/dragonboat/v4/config"
@@ -297,6 +298,7 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 			Removed:        make(map[uint64]bool),
 			NonVotings:     make(map[uint64]string),
 			Addresses:      make(map[uint64]string),
+			Witnesses:      make(map[uint64]string),
 		},
 		Type:    pb.OnDiskStateMachine,
 		ShardID: 345,
@@ -306,6 +308,7 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 	ss.Membership.Addresses[2] = "a2"
 	ss.Membership.Removed[3] = true
 	ss.Membership.NonVotings[4] = "a4"
+	ss.Membership.Witnesses[6] = "a6"
 	f1 := &pb.SnapshotFile{
 		Filepath: "/original_dir/external-1",
 		FileSize: 1,
@@ -323,15 +326,17 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 	members := make(map[uint64]string)
 	members[1] = "a1"
 	members[5] = "a5"
-	configChangeID := uint64(202)
 	finalDir := "final_data"
-	newss := GetProcessedSnapshotRecord(finalDir, ss, members, configChangeID, fs, false)
+	newss := GetProcessedSnapshotRecord(finalDir, ss, members, fs, false)
 	if newss.Index != ss.Index || newss.Term != ss.Term {
 		t.Errorf("index/term not copied")
 	}
-	if newss.Membership.ConfigChangeId != configChangeID {
+	if newss.Membership.ConfigChangeId != ss.Membership.ConfigChangeId {
 		t.Errorf("config change id not copied, %d, want %d",
-			newss.Membership.ConfigChangeId, configChangeID)
+			newss.Membership.ConfigChangeId, ss.Membership.ConfigChangeId)
+	}
+	if newss.Membership.ConfigChangeId == newss.Index {
+		t.Errorf("config change id unexpectedly copied from snapshot index")
 	}
 	if newss.Dummy != ss.Dummy || newss.ShardID != ss.ShardID || newss.Type != ss.Type {
 		t.Errorf("dummy/ShardId/Type fields not copied")
@@ -362,13 +367,62 @@ func TestGetProcessedSnapshotRecord(t *testing.T) {
 	if len(newss.Membership.NonVotings) != 0 {
 		t.Errorf("NonVotings not empty")
 	}
-	if len(newss.Membership.Removed) != 3 {
+	if len(newss.Membership.Removed) != 4 {
 		t.Errorf("unexpected removed count")
 	}
 	_, ok1 := newss.Membership.Removed[2]
 	_, ok2 := newss.Membership.Removed[3]
 	_, ok3 := newss.Membership.Removed[4]
-	if !ok1 || !ok2 || !ok3 {
+	_, ok4 := newss.Membership.Removed[6]
+	if !ok1 || !ok2 || !ok3 || !ok4 {
 		t.Errorf("unexpected removed content")
+	}
+}
+
+func TestGetProcessedSnapshotRecordWithOriginalMembership(t *testing.T) {
+	fs := vfs.GetTestFS()
+	ss := pb.Snapshot{
+		Filepath: "/original_dir/test.gbsnap",
+		FileSize: 123,
+		Index:    1023,
+		Term:     10,
+		Checksum: make([]byte, 8),
+		Membership: pb.Membership{
+			ConfigChangeId: 101,
+			Addresses:      map[uint64]string{1: "a1", 2: "a2"},
+			Removed:        map[uint64]bool{3: true},
+			NonVotings:     map[uint64]string{4: "a4"},
+			Witnesses:      map[uint64]string{5: "a5"},
+		},
+		Type:    pb.OnDiskStateMachine,
+		ShardID: 345,
+		Files: []*pb.SnapshotFile{{
+			Filepath: "/original_dir/external-1",
+			FileSize: 1,
+			FileId:   1,
+			Metadata: make([]byte, 8),
+		}},
+	}
+	finalDir := "final_data"
+	newss := GetProcessedSnapshotRecordWithOriginalMembership(finalDir, ss, fs)
+	if !reflect.DeepEqual(newss.Membership, ss.Membership) {
+		t.Errorf("membership not preserved, %+v, want %+v",
+			newss.Membership, ss.Membership)
+	}
+	if newss.Membership.ConfigChangeId == newss.Index {
+		t.Errorf("config change id unexpectedly copied from snapshot index")
+	}
+	if fs.PathDir(newss.Filepath) != finalDir {
+		t.Errorf("filepath not processed %s", newss.Filepath)
+	}
+	if fs.PathDir(newss.Files[0].Filepath) != finalDir {
+		t.Errorf("filepath in files not processed %s", newss.Files[0].Filepath)
+	}
+	newss.Membership.Addresses[1] = "changed"
+	if ss.Membership.Addresses[1] != "a1" {
+		t.Errorf("membership was not deep copied")
+	}
+	if ss.Files[0].Filepath != "/original_dir/external-1" {
+		t.Errorf("snapshot files were not copied before processing")
 	}
 }


### PR DESCRIPTION
Imported snapshots should not set Membership.ConfigChangeId to the snapshot index. ConfigChangeId tracks the raft entry index of the latest applied membership change, not a regular snapshot index.

This change keeps the two import paths distinct:

- NodeHost.SyncRequestImportSnapshot preserves the source snapshot membership exactly, including ConfigChangeId, Addresses, NonVotings, Witnesses, and Removed.
- tools.ImportSnapshot keeps its existing documented disaster-recovery behavior of rewriting membership from memberNodes, but no longer synthesizes ConfigChangeId from the snapshot index.

Tests:
- GOCACHE=/private/tmp/dragonboat-pr14-gocache go test ./tools -run "TestGetProcessedSnapshotRecord|TestGetProcessedSnapshotRecordWithOriginalMembership" -count=1
- GOCACHE=/private/tmp/dragonboat-pr14-gocache go test ./tools -count=1
- GOCACHE=/private/tmp/dragonboat-pr14-gocache go test . -run "TestRequestImportSnapshotAndQueryLog|TestImportSnapshot|TestOrderedMembershipChange|TestGetShardMembership" -count=1